### PR TITLE
Use t0 as fallback if win_open is NULL

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -127,10 +127,10 @@ function displayData(data) {
   }
 
   // if next rocket launch time is not available, timer context will display "Data not returned"
-  if (dailyResult.win_open == null) {
+  if (dailyResult.win_open == null && dailyResult.t0 == null) {
     timer.text("Data not returned");
   } else {
-    let launchTime = new Date(dailyResult.win_open);
+    let launchTime = new Date(dailyResult.win_open ?? dailyResult.t0);
     setInterval(function () {
       timeBetweenDates(launchTime);
     }, 1000);


### PR DESCRIPTION
Fix the timer not working because win_open can be NULL on some days. Use t0 as a fallback.